### PR TITLE
docs: add AGENTS.md with pre-commit hook policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Project Agent Configuration
+
+## Git Workflow
+
+**Pre-commit Hooks: NEVER Bypass**
+
+Pre-commit hooks perform essential validation including formatting, linting, and commit message checks. These hooks ensure code quality and consistency.
+
+- **Never** use `--no-verify` or `--no-gpg-sign` flags with git commands
+- **Never** skip hooks for any commit, including:
+  - Regular commits
+  - Hotfixes
+  - Emergency fixes
+  - WIP commits
+  - All other commits
+
+If a hook fails, fix the underlying issue rather than bypassing the hook.


### PR DESCRIPTION
## Summary
- Add AGENTS.md documenting that pre-commit hooks must never be bypassed
- Establishes policy for all commits (regular, hotfixes, emergency fixes, WIP)

## Motivation
Pre-commit hooks perform essential validation including formatting, linting, and commit message checks. This policy ensures code quality and consistency are maintained.

## Changes
- Created AGENTS.md with minimal, focused instructions
- Documents that `--no-verify` and `--no-gpg-sign` flags must never be used
- Applies to all commits with no exceptions