### PR TITLE
fix(specs): explain interpretation nature, fix broken prev link

### DIFF
--- a/docs/learn/spec.md
+++ b/docs/learn/spec.md
@@ -57,4 +57,4 @@ The spec leaves some things to the application layer:
 
 ✅ **Full compliance** with draft-ietf-httpapi-idempotency-key-header-07
 
-All MUST and SHOULD requirements are implemented. The library gives you the flexibility to choose which optional features to enable based on your API's needs.
+All MUST and SHOULD requirements are implemented.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -7,7 +7,7 @@ next: false
 
 # Cucumber Specifications
 
-These Cucumber specifications represent idempot.dev's interpretation and opinions on how [draft-ietf-httpapi-idempotency-key-header-07](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07) should be implemented. While the IETF draft defines the requirements, these specs codify specific implementation choices that ensure consistency across all idempot.dev projects.
+These Cucumber specifications codify idempot.dev's interpretation of [draft-ietf-httpapi-idempotency-key-header-07](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07). The IETF draft defines the requirements; these specs translate them into implementation choices shared by all idempot.dev projects.
 
 ## Overview
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -1,13 +1,13 @@
 ---
 prev:
   text: "Why Idempotency"
-  link: "/why-idempotency"
+  link: "/learn/why"
 next: false
 ---
 
 # Cucumber Specifications
 
-RFC 7807-compliant specifications for idempotency middleware implementations.
+These Cucumber specifications represent idempot.dev's interpretation and opinions on how [draft-ietf-httpapi-idempotency-key-header-07](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07) should be implemented. While the IETF draft defines the requirements, these specs codify specific implementation choices that ensure consistency across all idempot.dev projects.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Add explanatory text about specs being idempot.dev's interpretation of the IETF draft
- Fix broken prev link: `/why-idempotency` → `/learn/why`