### PR TITLE
feat(homepage): add Learn feature, link features to content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,10 @@ hero:
 features:
   - title: IETF Spec Compliant
     details: Implements draft-ietf-httpapi-idempotency-key-header-07
-  - title: Request Fingerprinting
-    details: Detects conflicts when the same key is used with different payloads
+    link: /learn/spec
+  - title: Learn
+    details: Understand why idempotency matters for reliable APIs
+    link: /learn/
 ---
 
 ## Projects


### PR DESCRIPTION
## Summary

- Add new "Learn" feature linking to `/learn/`
- Link "IETF Spec Compliant" feature to `/learn/spec`
- Remove "Request Fingerprinting" feature