### PR TITLE
feat: add lychee link checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,55 @@
+name: Link Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight
+
+jobs:
+  link-checker:
+    name: Link Checker
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write  # Required for creating issues from file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Check all files in the built site
+          args: |
+            .vitepress/dist
+            --root-dir .vitepress/dist
+            --include-mail=false
+            --exclude "^file://"
+            --accept '200..=299,403'
+          # Don't fail action on broken links (we'll create an issue instead)
+          fail: false
+          # Output format
+          format: markdown
+          # Output file path
+          output: lychee/out.md
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,json,md}\"",
     "lint": "eslint .vitepress/config.mjs",
-    "lint:fix": "eslint .vitepress/config.mjs --fix"
+    "lint:fix": "eslint .vitepress/config.mjs --fix",
+    "lint:links": "./scripts/link-check.sh"
   },
   "lint-staged": {
     "*.js": [

--- a/scripts/link-check.sh
+++ b/scripts/link-check.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "Running lychee link check on dist folder..."
+lychee .vitepress/dist \
+    --root-dir .vitepress/dist \
+    --include-mail=false \
+    --exclude "^file://" \
+    --accept '200..=299,403'


### PR DESCRIPTION
## Summary

Add automated link checking using [lychee](https://github.com/lycheeverse/lychee) to detect broken links in the built VitePress site.

## Changes

- **package.json**: Add 
pm run lint:links/script to run link checker locally
- **scripts/link-check.sh**: Shell script for local link checking using lychee
- **.github/workflows/link-check.yml**: GitHub Actions workflow for automated link checking on CI

## How it works

The link checker:
- Runs against the built 
.vitepress/distolder (not source files)
- Excludes local 
file://
URLs
- Accepts 200-299 and 403 status codes (npm returns 403 for bots)
- Runs on push to main, pull requests, and daily schedule
- Creates GitHub issues for broken link reports

## Usage


> build
> vitepress build


  vitepress v2.0.0-alpha.17

build complete in 6.72s.

> lint:links
> ./scripts/link-check.sh

Running lychee link check on dist folder...
🔍 518 Total (in 1s 139ms) 🔗 228 Unique ✅ 116 OK 🚫 0 Errors 👻 383 Excluded ⛔ 19 Unsupported 🔀 12 Redirects

## Notes

- 12 redirect warnings are expected (YouTube URLs redirect normally)
- npmjs.com links return 403 but are accepted as valid
- Uses Homebrew-installed lychee locally, lycheeverse/lychee-action on CI